### PR TITLE
fix: update labels in `manager.yaml` 

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,16 +18,17 @@ metadata:
   namespace: system
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: deployment
+    app.kubernetes.io/name: zookeeper-operator
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: zookeeper-operator
+    app.kubernetes.io/created-by: operator-lifecycle-manager
     app.kubernetes.io/part-of: zookeeper-operator
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: zookeeper-operator
   replicas: 1
   template:
     metadata:
@@ -35,6 +36,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/name: zookeeper-operator
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/config/manifests/bases/zookeeper-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/zookeeper-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ spec:
       name: zookeeperznodes.zookeeper.zncdata.dev
       version: v1alpha1
   description: zookeeper operator
-  displayName: \zookeeper-operator
+  displayName: zookeeper-operator
   icon:
   - base64data: ""
     mediatype: ""


### PR DESCRIPTION
update labels in `manager.yaml` to resolve multi controller manager in same cluster

note: after updated, we must make bundle to apply the patch

close https://github.com/zncdatadev/zookeeper-operator/issues/51