### PR TITLE
fix: an error when the zk cluster namespace was not specified for the znode 

### DIFF
--- a/test/e2e/default/00-assert.yaml
+++ b/test/e2e/default/00-assert.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: zookeepercluster-sample-default
-  namespace: kubedatastack
 status:
   availableReplicas: 3
   replicas: 3

--- a/test/e2e/default/00-cluster.yaml
+++ b/test/e2e/default/00-cluster.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: zookeeper-operator
   name: zookeepercluster-sample
-  namespace: kubedatastack
 spec:
   image:
     repository: docker.io/bitnami/zookeeper

--- a/test/e2e/default/01-assert.yaml
+++ b/test/e2e/default/01-assert.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: sample-znode
-  namespace: kubedatastack
-

--- a/test/e2e/default/01-znode.yaml
+++ b/test/e2e/default/01-znode.yaml
@@ -11,4 +11,3 @@ metadata:
 spec:
   clusterRef:
     name: zookeepercluster-sample
-    namespace: kubedatastack


### PR DESCRIPTION
1. Update namespace logic for `clusterRef` of znode:
   - When `clusterRef` is nil, use the znode CR's namespace.
2. Add checking to ensure znode exists in the Zookeeper cluster.
3. Update e2e tests to reflect the new changes.
