### PR TITLE
feat: enhance znode management with finalizer and logging improvements

### DIFF
--- a/config/samples/zookeeper_v1alpha1_zookeepercluster.yaml
+++ b/config/samples/zookeeper_v1alpha1_zookeepercluster.yaml
@@ -13,9 +13,7 @@ spec:
     repository: docker.io/bitnami/zookeeper
     tag: 3.9.1-debian-12-r15
   clusterConfig:
-    service:
-      type: NodePort
-      port: 2181
+    listenerClass: external-unstable
   server:
     config:
       resources:


### PR DESCRIPTION
This commit enhances the Znode controller's functionality by introducing a finalizer mechanism and improving logging for ZooKeeper client operations.

1. **Fix `listenerClass` Value in ZooKeeper Cluster Sample:**
   - Corrected the value of `listenerClass` in the ZooKeeper cluster sample configuration to ensure it matches the expected format or class name. This ensures that the listener is properly initialized and functions as intended.

2. **Znode Controller Finalizer:**
   - Implemented a finalizer mechanism in the Znode controller to handle the deletion of znodes from the ZooKeeper cluster when the corresponding Kubernetes resource is deleted. This ensures that all znodes are properly cleaned up, preventing orphaned data in the ZooKeeper cluster.

3. **Add Finalizer for Deleting Znode:**
   - Added a finalizer to the Znode controller to manage the lifecycle of znodes. When a Znode resource is deleted, the controller will perform necessary cleanup operations, such as deleting the znode from the ZooKeeper cluster, before removing the finalizer.

4. **Add Logs for Debugging ZooKeeper Client Operations:**
   - Introduced detailed logging statements within the ZooKeeper client operations to capture information about the operations being performed, such as creating, updating, and deleting znodes. These logs will aid in debugging and provide operational insights.