### PR TITLE
fix: controller error when delete znode path in zk 

### DIFF
--- a/config/manifests/bases/zookeeper-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/zookeeper-operator.clusterserviceversion.yaml
@@ -3,8 +3,8 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[]'
-    categories: Big Data
     capabilities: Basic Install
+    categories: Big Data
   name: zookeeper-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
- Implemented recursive deletion of znodes to handle cases where a znode has children.
- Added a depth-first traversal method to ensure all child znodes are deleted before the parent.
