### PR TITLE
fix: fix znode subset deletion requiring parent path and recursive deletion algorithm

### DIFF
--- a/api/v1alpha1/zookeepercluster_types.go
+++ b/api/v1alpha1/zookeepercluster_types.go
@@ -101,7 +101,7 @@ type ImageSpec struct {
 }
 
 type ClusterConfigSpec struct {
-	// +kubebuilder:validation:required
+	// +kubebuilder:validation:optional
 	// +kubebuilder:validation:Enum="cluster-internal";"external-unstable"
 	// +kubebuilder:default="cluster-internal"
 	ListenerClass string `json:"listenerClass"`


### PR DESCRIPTION
Addressed the following specific issues:
1. Deleting a subset of znodes required the full parent path, resulting in a "zk: invalid path" error if not provided.
2. The recursive deletion algorithm only deleted the last-level path, failing to handle intermediate-level child nodes.
