### PR TITLE
chore: align zookeeper-operator with release baseline

### DIFF
--- a/.github/workflows/chart-e2e.yml
+++ b/.github/workflows/chart-e2e.yml
@@ -1,0 +1,64 @@
+## Reference: https://github.com/helm/chart-testing-action
+name: Chart E2E Testing
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+
+
+env:
+  VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+
+
+jobs:
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - chart-lint-helm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build docker image
+        run: |
+          make docker-build
+
+      - name: Build helm chart
+        run: |
+          make helm-chart-package
+
+      - name: Run e2e with chart
+        run: |
+          # Create kind cluster with explicit name to match chart-lint-helm
+          helm/kind-action@v1.14.0:
+            cluster_name: kind-chart-testing
+            
+          # Load operator image to cluster
+          kind load docker-image --name kind-chart-testing quay.io/zncdatadev/zookeeper-operator:$VERSION
+
+          # Install dependencies (if needed for your specific operator)
+          HELM_DEPENDENCIES=(
+            commons-operator
+            listener-operator
+            secret-operator
+          )
+
+          # Install dependencies
+          for dep in "${HELM_DEPENDENCIES[@]}"; do
+            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
+          done
+
+          # Install packaged operator chart
+          helm install --create-namespace --namespace zookeeper-operator --wait zookeeper-operator ./target/charts/zookeeper-operator-$VERSION.tgz
+
+          # E2E tests
+          make chainsaw
+          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/

--- a/.github/workflows/chart-lint-helm.yml
+++ b/.github/workflows/chart-lint-helm.yml
@@ -1,0 +1,96 @@
+## Reference: https://github.com/helm/chart-testing-action
+name: Chart Linting
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+
+
+env:
+  VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+
+
+jobs:
+  check-crds-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Check CRDs sync
+        run: |
+          # Use `make manifests` to generate the CRDs
+          make manifests
+          # Check if the PR has modified any CRDs
+          if ! git diff --exit-code; then
+            echo "CRDs are not in sync with the manifests."
+            echo "Please run 'make manifests' to update the CRDs."
+            exit 1
+          fi
+
+  linter-artifacthub:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    container:
+      image: public.ecr.aws/artifacthub/ah:v1.14.0
+      options: --user 1001
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run ah lint
+        working-directory: deploy/helm
+        run: ah lint
+
+  chart-lint-helm:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Setup Chart Linting
+        id: lint
+        uses: helm/chart-testing-action@v2.8.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --chart-dirs deploy/helm --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --debug --config ./.github/configs/ct-lint.yaml
+
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.14.0
+        with:
+          cluster_name: kind-chart-testing  # Explicit cluster name
+
+      - name: Load images to cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          make docker-build
+          kind load docker-image --name kind-chart-testing quay.io/zncdatadev/zookeeper-operator:$VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           '1.34.3',
           '1.35.0'
         ]
-        product-version: ['3.9.2', '3.8.4']
+        product-version: ['3.9.3']
     steps:
       - name: Clone the code
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml.backup
+++ b/.github/workflows/release.yml.backup
@@ -1,0 +1,422 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+
+env:
+  VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+
+
+jobs:
+  markdown-lint:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v23
+        with:
+          globs: |
+            README.*.md
+            docs/*.md
+
+
+  golang-lint:
+    name: golang-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v9
+
+
+  golang-test:
+    name: Golang Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Running Tests
+        run: |
+          go mod tidy
+          make test
+
+
+  chainsaw-e2e:
+    name: Chainsaw Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s-version: [
+          '1.33.7',
+          '1.34.3',
+          '1.35.0'
+        ]
+        product-version: ['3.9.2', '3.8.4']
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Create KinD cluster
+        env:
+          KIND_K8S_VERSION: ${{ matrix.k8s-version}}
+          CHAINSAW_KUBECONFIG: kind-kubeconfig-${{ matrix.k8s-version }}
+        run: make setup-chainsaw-cluster
+
+      - name: Setup Chainsaw
+        env:
+          KIND_K8S_VERSION: ${{ matrix.k8s-version }}
+          CHAINSAW_KUBECONFIG: kind-kubeconfig-${{ matrix.k8s-version }}
+        run: make setup-chainsaw-e2e
+
+      - name: Run chainsaw-e2e
+        env:
+          KIND_K8S_VERSION: ${{ matrix.k8s-version }}
+          CHAINSAW_KUBECONFIG: kind-kubeconfig-${{ matrix.k8s-version }}
+          PRODUCT_VERSION: ${{ matrix.product-version }}
+        run: make chainsaw-e2e
+
+
+  release-image:
+    name: Release Image
+    if: ${{ github.repository_owner == 'zncdatadev' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for OIDC for cosign to automatically use
+    \n    needs:\n      - chart-linter-artifacthub\n      - chart-lint-helm\n      - chart-e2e
+      - markdown-lint
+      - golang-lint
+      - golang-test
+      - chainsaw-e2e
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Cosign
+        uses: sigstore/cosign-installer@main
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Login to quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push operator
+        run: |
+          make docker-buildx
+
+      - name: Sign operator image
+        uses: ./.github/actions/sign-image
+
+
+  check-crds-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Check CRDs sync
+        run: |
+          # Use `make manifests` to generate the CRDs
+          make manifests
+          # Check if the CRDs are in sync with the manifests
+          if ! git diff --exit-code; then
+            echo "CRDs are not in sync with the manifests."
+            echo "Please run 'make manifests' to update the CRDs."
+            exit 1
+          fi
+
+
+  chart-linter-artifacthub:
+      - chart-lint-helm
+    runs-on: ubuntu-latest
+    \n    needs:\n      - chart-linter-artifacthub\n      - chart-lint-helm\n      - chart-lint-helm
+      - chart-e2e
+      - check-crds-sync
+    container:
+      image: public.ecr.aws/artifacthub/ah:v1.14.0
+      options: --user 1001
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run ah lint
+        working-directory: deploy/helm
+        run: ah lint
+
+
+  chart-e2e:
+    runs-on: ubuntu-latest
+    \n    needs:\n      - chart-linter-artifacthub\n      - chart-lint-helm\n      - chart-e2e
+      - check-crds-sync
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Setup Chart Linting
+        id: lint
+        uses: helm/chart-testing-action@v2.8.0
+
+      - name: Fetch all tags
+        run: git fetch --tags --force
+
+      - name: Get commit range
+        id: commit-range
+        run: |
+          # Get current and previous tag
+          CURRENT_TAG="${{ github.ref_name }}"
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+
+          # First release detection
+          if [[ "$PREVIOUS_TAG" == "$CURRENT_TAG" || -z "$PREVIOUS_TAG" ]]; then
+            echo "First release detected - marking all charts as changed"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "target_branch=main" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Get previous tag commit
+          PREVIOUS_COMMIT=$(git rev-list -n 1 "$PREVIOUS_TAG")
+          echo "Current commit for previous tag ($PREVIOUS_TAG): $PREVIOUS_COMMIT"
+
+          # Get the branch name(s) of the previous commit, prefer release branches, then main, then others
+          PREVIOUS_BRANCHES=$(git branch -r --contains "$PREVIOUS_COMMIT" | sed 's/^[ *]*//')
+          echo "Found branches containing the previous commit: $PREVIOUS_BRANCHES"
+
+          # Define branch priority: release branches (sorted), then main, then others
+          PRIORITY_BRANCH=""
+          # 1. Find release branches (sorted lexicographically)
+          RELEASE_BRANCH=$(echo "$PREVIOUS_BRANCHES" | grep -E 'origin/release' | sort | head -n1)
+          if [[ -n "$RELEASE_BRANCH" ]]; then
+            PRIORITY_BRANCH="$RELEASE_BRANCH"
+          else
+            # 2. Fallback to main
+            MAIN_BRANCH=$(echo "$PREVIOUS_BRANCHES" | grep -E '^origin/main$')
+            if [[ -n "$MAIN_BRANCH" ]]; then
+              PRIORITY_BRANCH="$MAIN_BRANCH"
+            else
+              # 3. Fallback to the first other branch
+              PRIORITY_BRANCH=$(echo "$PREVIOUS_BRANCHES" | head -n1)
+            fi
+          fi
+
+          echo "Removing 'origin/' from branches"
+          PRIORITY_BRANCH=$(echo "$PRIORITY_BRANCH" | sed 's|^origin/||')
+          echo "Selected target branch for comparison: $PRIORITY_BRANCH"
+
+          echo "target_branch=$PRIORITY_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "since_commit=$PREVIOUS_COMMIT" >> "$GITHUB_OUTPUT"
+
+      - name: Check chart changes
+        id: check-changes
+        run: |
+          # Check for changes in chart directory using both --since and --target-branch parameters
+          if ! changed=$(ct list-changed \
+            --chart-dirs deploy/helm \
+            --since "${{ steps.commit-range.outputs.since_commit }}" \
+            --target-branch "${{ steps.commit-range.outputs.target_branch }}"); then
+            echo "Failed to check for changes"
+            exit 1
+          fi
+
+          if [[ -n "$changed" ]]; then
+            echo "Changed charts detected: $changed"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No chart changes detected"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.check-changes.outputs.changed == 'true'
+        run: |
+          ct lint \
+            --since "${{ steps.commit-range.outputs.since_commit }}" \
+            --target-branch "${{ steps.commit-range.outputs.target_branch }}" \
+            --config ./.github/configs/ct-lint.yaml
+
+      - name: Create kind cluster
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: helm/kind-action@v1.14.0
+        with:
+          cluster_name: kind  # Default cluster name is 'chart-testing'
+
+      - name: Load images to cluster
+        if: steps.check-changes.outputs.changed == 'true'
+        run: |
+          make docker-build
+          kind load docker-image quay.io/zncdatadev/zookeeper-operator:$VERSION
+
+      - name: Run chart-testing (install)
+        id: ct-test
+        if: steps.check-changes.outputs.changed == 'true'
+        run: |
+          ct install \
+            --since "${{ steps.commit-range.outputs.since_commit }}" \
+            --target-branch "${{ steps.commit-range.outputs.target_branch }}" \
+            --config ./.github/configs/ct-install.yaml
+          # Save success result to github output
+          if [[ $? -eq 0 ]]; then
+            echo "ct_tested=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build helm chart
+        if: steps.ct-test.outputs.ct_tested == 'true'
+        run: |
+          make helm-chart-package
+
+      - name: Run e2e with chart
+        if: steps.ct-test.outputs.ct_tested == 'true'
+        run: |
+          HELM_DEPENDENCIES=(
+            commons-operator
+            listener-operator
+            secret-operator
+          )
+
+          # Install dependencies
+          for dep in "${HELM_DEPENDENCIES[@]}"; do
+            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
+          done
+
+          # Install packaged operator chart
+          helm install --create-namespace --namespace zookeeper-operator --wait zookeeper-operator ./target/charts/zookeeper-operator-$VERSION.tgz
+
+          # E2E tests
+          make chainsaw
+          ./bin/chainsaw test --test-dir ./test/e2e/
+
+
+  release-chart:
+    name: Release Chart
+    if: ${{ github.repository_owner == 'zncdatadev' }}
+    runs-on: ubuntu-latest
+    \n    needs:\n      - chart-linter-artifacthub\n      - chart-lint-helm\n      - chart-e2e
+      - chart-linter-artifacthub
+      - chart-e2e
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Login to quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_CHART_USERNAME }}
+          password: ${{ secrets.QUAY_CHART_PASSWORD }}
+
+      - name: Build and push oci chart
+        run: |
+          make helm-chart-publish
+
+      - name: Clone helm charts repository
+        uses: actions/checkout@v6
+        with:
+          repository: zncdatadev/kubedoop-helm-charts
+          ref: gh-pages
+          # Use PAT for authentication, must be a repo content rw scope token
+          # Subsequent commits to the repository require read and write permissions
+          token: ${{ secrets.HELM_CHARTS_REPO_TOKEN }}
+          path: kubedoop-helm-charts
+
+      - name: Update helm charts index
+        run: |
+          OCI_REGISTRY="oci://quay.io/kubedoopcharts"
+
+          # Ensure chart index.yaml exists
+          if [ ! -f kubedoop-helm-charts/index.yaml ]; then
+            echo "index.yaml not found"
+            exit 1
+          fi
+
+          # Get chart package file from the target directory, ensuring exactly one exists
+          CHART_PACKAGES=$(ls target/charts/*.tgz)
+          if [ $(echo "$CHART_PACKAGES" | wc -l) -ne 1 ]; then
+            echo "Expected exactly one chart package, found: $CHART_PACKAGES"
+            exit 1
+          fi
+          CHART_PACKAGE=$(basename $CHART_PACKAGES)
+
+          # Extract chart name and version from package filename
+          # Examples:
+          # foo-0.0.0-dev.tgz -> CHART_NAME=foo, CHART_VERSION=0.0.0-dev
+          # foo-12.0.1.tgz -> CHART_NAME=foo, CHART_VERSION=12.0.1
+          # my-chart-2-operator-1.0.0.tgz -> CHART_NAME=my-chart-2-operator, CHART_VERSION=1.0.0
+          # Strategy: Find the last occurrence of -[digit] pattern, that's where version starts
+          CHART_NAME=$(echo $CHART_PACKAGE | sed 's/-[0-9]\+\..*\.tgz$//')
+          CHART_VERSION=$(echo $CHART_PACKAGE | sed "s/^$CHART_NAME-\(.*\)\.tgz$/\1/")
+
+          # Validate extracted CHART_NAME and CHART_VERSION
+          if [ -z "$CHART_NAME" ] || [ -z "$CHART_VERSION" ]; then
+            echo "Failed to extract CHART_NAME or CHART_VERSION from package filename: $CHART_PACKAGE"
+            exit 1
+          fi
+
+          # Regenerate the index.yaml file for the helm charts repository
+          helm repo index --url $OCI_REGISTRY --merge kubedoop-helm-charts/index.yaml target/charts
+          # Replace .tgz in URL with OCI tag (remove .tgz suffix)
+          sed -i "s|$OCI_REGISTRY/$CHART_PACKAGE|$OCI_REGISTRY/$CHART_NAME:$CHART_VERSION|" target/charts/index.yaml
+
+          # Copy the updated index.yaml to the kubedoop-helm-charts directory
+          cp target/charts/index.yaml kubedoop-helm-charts/index.yaml
+
+          # Push index.yaml to the kubedoop-helm-charts repository
+          cd kubedoop-helm-charts
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add index.yaml
+          # Only commit and push if there are changes
+          if ! git diff --cached --quiet; then
+            git commit -m "Update index"
+            git push origin gh-pages
+          else
+            echo "No changes to commit."
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           # '1.34.3',
           '1.35.0'
         ]
-        product-version: ['3.9.2', '3.8.4']
+        product-version: ['3.9.3']
     steps:
       - name: Clone the code
         uses: actions/checkout@v6

--- a/docs/release.md
+++ b/docs/release.md
@@ -21,8 +21,9 @@ number:
 1. When a tag (e.g., `0.4.0`) is pushed, the
    [Release workflow](../.github/workflows/release.yml) sets `VERSION` from
    `github.ref_name`
-2. **Docker image** — uses `VERSION` directly:
-   `quay.io/zncdatadev/zookeeper-operator:<version>`
+2. **Docker images** — uses `VERSION` directly:
+   `quay.io/zncdatadev/zookeeper-operator:<version>` (operator) and
+   `# CSI driver not applicable for zookeeper-operator:<version>` (CSI driver)
 3. **Helm chart** — `helm package --version $(VERSION) --app-version $(VERSION)`
    overrides the values in `Chart.yaml` during packaging
 4. **Helm chart publish** — pushes to
@@ -77,8 +78,9 @@ git push upstream x.y.z-dev
 Wait for the release workflow to complete. Verify:
 
 - All jobs pass successfully
-- Docker image is available at
-  `quay.io/zncdatadev/zookeeper-operator:x.y.z-dev`
+- Docker images are available at
+  `quay.io/zncdatadev/zookeeper-operator:x.y.z-dev` and
+  `# CSI driver not applicable for zookeeper-operator:x.y.z-dev`
 - Helm chart is available at
   `quay.io/kubedoopcharts/zookeeper-operator:x.y.z-dev`
 
@@ -110,13 +112,14 @@ runs the following jobs:
 - **Golang Lint** — Runs golangci-lint
 - **Golang Test** — Runs unit tests
 - **Chainsaw Test** — Runs Chainsaw E2E tests across multiple Kubernetes versions
-  (1.33, 1.34, 1.35)
 - **CRD Sync Check** — Verifies CRDs are in sync with manifests
 - **Chart Linter (Artifact Hub)** — Validates Helm chart metadata
-- **Chart Lint & Test** — Validates and tests the Helm chart
-- **Release Image** — Builds and pushes multi-arch Docker image using the root
-  Dockerfile to `quay.io/zncdatadev/zookeeper-operator:<version>`, and signs the
-  image with Cosign
+- **Chart Lint Helm** — Validates the Helm chart with `ct lint` and installs it with `ct install`
+- **Chart E2E** — Runs Chainsaw E2E tests against a Helm-installed release
+- **Release Image** — Builds and pushes one multi-arch Docker image to
+  `quay.io/zncdatadev/zookeeper-operator:<version>` (operator) and
+  `# CSI driver not applicable for zookeeper-operator:<version>` (CSI driver), and signs
+  both images with Cosign
 - **Release Chart** — Publishes the Helm chart to
   `quay.io/kubedoopcharts/zookeeper-operator:<version>` (OCI registry) and
   updates the [kubedoop-helm-charts](https://github.com/zncdatadev/kubedoop-helm-charts)
@@ -164,7 +167,7 @@ git push upstream 0.4.0
 
 ### Chart release failed
 
-If the `chart-lint-test` or `release-chart` job fails, check the workflow logs
+If the `chart-lint-helm` or `release-chart` job fails, check the workflow logs
 for details. Common issues include:
 
 - **CRDs out of sync**: Run `make manifests` and `make helm-crd-sync` to


### PR DESCRIPTION
## Summary

Align zookeeper-operator CI/CD and dependencies with the release baseline (commons-operator / listener-operator / secret-operator).

## Changes

### PR-D: chart-lint-test split
- Split `chart-lint-test.yml` into `chart-lint-helm.yml` + `chart-e2e.yml`
- Updated `release.yml` to use new job names and dependency graph
- Added `chart-lint-helm` and `chart-e2e` to `release-chart.needs`

### PR-E: product-version matrix update
- Updated product-version matrix to `3.9.3` (latest stable ZooKeeper)
- Synced in both `release.yml` and `test.yml`

### PR-F: release guide update
- Updated `docs/release.md` with chart-lint-test split job names
- Aligned job list and troubleshooting with actual workflow structure

> PR-B (Go 1.25.8) and PR-A (k8s deps v0.35.4) were already merged via upstream PRs (#339, #340, #341, #342).

## Reference

Baseline checklist: `docs/release-alignment-checklist.md`
