### PR TITLE
ci: update product-version matrix to 3.9.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           '1.34.3',
           '1.35.0'
         ]
-        product-version: ['3.9.2', '3.8.4']
+        product-version: ['3.9.3']
     steps:
       - name: Clone the code
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           # '1.34.3',
           '1.35.0'
         ]
-        product-version: ['3.9.2', '3.8.4']
+        product-version: ['3.9.3']
     steps:
       - name: Clone the code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Update the ZooKeeper product-version matrix to the latest stable version `3.9.3`.

## Changes

- `release.yml`: `product-version: ['3.9.2', '3.8.4']` → `['3.9.3']`
- `test.yml`: same update
