### PR TITLE
fix: use CR spec productVersion in GetImage() and update default to 3.9.3

### DIFF
--- a/api/v1alpha1/image.go
+++ b/api/v1alpha1/image.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	DefaultRepository     = "quay.io/zncdatadev"
-	DefaultProductVersion = "3.9.2"
+	DefaultProductVersion = "3.9.3"
 	DefaultProductName    = "zookeeper"
 )
 

--- a/internal/clustercontroller/cluster/cluster.go
+++ b/internal/clustercontroller/cluster/cluster.go
@@ -53,10 +53,15 @@ func NewClusterReconciler(
 }
 
 func (r *Reconciler) GetImage() *util.Image {
+	productVersion := zkv1alpha1.DefaultProductVersion
+	if r.Spec.Image.ProductVersion != "" {
+		productVersion = r.Spec.Image.ProductVersion
+	}
+
 	image := util.NewImage(
 		zkv1alpha1.DefaultProductName,
 		zkversion.BuildVersion,
-		zkv1alpha1.DefaultProductVersion,
+		productVersion,
 		func(options *util.ImageOptions) {
 			options.Custom = r.Spec.Image.Custom
 			options.Repo = r.Spec.Image.Repo


### PR DESCRIPTION
## Summary

GetImage() was hardcoded to use `DefaultProductVersion` (3.9.2), ignoring the `productVersion` field set in the ZookeeperCluster CR spec. This caused the operator to build image tag `quay.io/zncdatadev/zookeeper:3.9.2-kubedoop0.4.0-dev` which does not exist on quay.io (only `3.9.3-kubedoop0.4.0-dev` exists for the dev variant). Pods entered `ImagePullBackOff`, StatefulSet stayed at `availableReplicas=0`, and both Chainsaw Test and chart-e2e timed out.

## Changes
- **cluster.go**: Honor `r.Spec.Image.ProductVersion` when set by the user, falling back to `DefaultProductVersion`
- **image.go**: Update `DefaultProductVersion` from `3.9.2` to `3.9.3` for release-0.4

## Impact
Fixes CI failures on all k8s versions (1.26.15, 1.33.7, 1.34.3) and unblocks Release Image/Chart jobs.