### PR TITLE
fix(e2e): replace bash-specific [[ with POSIX [ for /bin/sh compatibility

### DIFF
--- a/test/e2e/smoke/observability/chainsaw-test.yaml
+++ b/test/e2e/smoke/observability/chainsaw-test.yaml
@@ -129,14 +129,14 @@ spec:
             # Query with retries
             for i in {1..3}; do
               TARGETS=$(curl -s http://localhost:9090/api/v1/targets 2>/dev/null)
-              if [[ -n "$TARGETS" ]]; then
+              if [ -n "$TARGETS" ]; then
                 break
               fi
               echo "Retry $i/3..."
               sleep 2
             done
 
-            if [[ -z "$TARGETS" ]]; then
+            if [ -z "$TARGETS" ]; then
               echo "✗ Failed to query Prometheus targets"
               exit 1
             fi


### PR DESCRIPTION
Chainsaw executes scripts with /usr/bin/sh (dash on Ubuntu), which does not support [[. Replace [[ -n/-z ]] with [ -n/-z ] in observability test.