### PR TITLE
chore: add AI worktree development mode configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target
 
 # ai tools
 .omc/
+
+# AI worktree
+.worktree/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,4 +46,22 @@ Manages Apache ZooKeeper deployments on Kubernetes. Handles creation, configurat
 - controller-runtime
 - Kubernetes client-go
 
+### AI Worktree Development Mode
+
+**IMPORTANT**: When making code changes, work in a worktree under `.worktree/`, NOT in the main working directory.
+
+#### Workflow
+1. Create worktree: `git worktree add .worktree/<branch-name> -b <branch-name>`
+2. Work in `.worktree/<branch-name>/` directory
+3. Test: `cd .worktree/<branch-name> && make lint && make test`
+4. Commit changes in the worktree
+5. Push and create PR from the worktree branch
+6. Cleanup: `git worktree remove .worktree/<branch-name>`
+
+#### Rules
+- NEVER modify files directly in the main working directory
+- Each task gets its own worktree with a descriptive branch name
+- Run `make generate` if API structs are modified
+- Run `make lint && make test` before committing
+
 <!-- MANUAL: -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

Add worktree-based development mode configuration for AI-assisted development.

### Changes
- **CLAUDE.md**: Add worktree development workflow instructions
- **.gitignore**: Add `.worktree/` to gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)