### PR TITLE
build: align the linter version and chart CRDs with the release baseline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,3 +37,8 @@ jobs:
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v9
+        with:
+          # Pin the linter version so a new upstream release cannot break the
+          # pipeline without a code change. Keep in sync with the Makefile's
+          # GOLANGCI_LINT_VERSION.
+          version: v2.12.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  # Allow a manual run so the publish credentials can be verified on demand.
+  # Without this the only way to exercise them is to land a commit on main,
+  # which is how an expired HELM_CHARTS_REPO_TOKEN went unnoticed for weeks.
+  workflow_dispatch:
 
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,11 @@ jobs:
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v9
+        with:
+          # Pin the linter version so a new upstream release cannot break the
+          # pipeline without a code change. Keep in sync with the Makefile's
+          # GOLANGCI_LINT_VERSION.
+          version: v2.12.1
 
 
   golang-test:

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.8.0
+GOLANGCI_LINT_VERSION ?= v2.12.1
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/deploy/helm/zookeeper-operator/crds/crds.yaml
+++ b/deploy/helm/zookeeper-operator/crds/crds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: zookeeperclusters.zookeeper.kubedoop.dev
 spec:
   group: zookeeper.kubedoop.dev
@@ -614,7 +614,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: zookeeperznodes.zookeeper.kubedoop.dev
 spec:
   group: zookeeper.kubedoop.dev


### PR DESCRIPTION
## Why

Part of the 0.4.0 release baseline alignment. zookeeper-operator is wave 4 and
is the prerequisite for hdfs, hive, kafka and nifi, so it needs to be on the
baseline before those can be cut.

**golangci-lint was floating.** `golangci-lint-action` was invoked with no
`version:` input, so CI always installed the newest release. That makes the
pipeline break on an upstream release with no change here, and it silently
diverges from what `make lint` runs locally. The Makefile was also on v2.8.0
rather than the v2.12.1 baseline.

**The chart CRDs had drifted.** `deploy/helm/zookeeper-operator/crds/crds.yaml`
was still generated by controller-gen v0.17.1 while `config/crd/bases` had
already moved to v0.19.0. The `check-crds-sync` job only covers `config/`, so
this copy can drift indefinitely without CI noticing — `make helm-crd-sync` is
the only thing that catches it. This is not specific to this repo: 11 of the 15
operators are in the same state.

Separately, `publish.yml` could only be triggered by a push to main. That is how
an expired `HELM_CHARTS_REPO_TOKEN` went unnoticed for weeks: nothing landed on
main during that window, so nothing exercised the credential, and it only
surfaced when an unrelated change finally did. Adding `workflow_dispatch` makes
the publish path verifiable on demand — the alternative is discovering a dead
credential at tag time, when the tag cannot be recut.

## Verification

Run locally against these changes:

| Gate | Result |
|---|---|
| `make lint` (v2.12.1) | **0 issues** |
| `make test` | all packages pass |
| `check-crds-sync` (simulated per the CI logic, clean tree) | passes |
| `make helm-crd-sync` | no drift after the regeneration commit |
| Workflow YAML syntax | valid; `workflow_dispatch` parses as expected |

> Authored from a `.worktree/` checkout per this repo's AGENTS.md, so the
> in-flight `refactor/base-operator-go` working tree was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)